### PR TITLE
Add ability to register templates in sub directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.2.0
+
+* Add ability to register templates in sub directories
+
 ## 0.1.0
 
 * Initial release.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Page Templates
 
-Unregister page templates through configuration.
+Register and unregister page templates through configuration.
 
 ## Installation
 
@@ -8,7 +8,9 @@ This component should be installed using Composer, with the command `composer re
 
 ## Usage
 
-Within your config file (typically found at `config/defaults.php`) define an array of page templates you would like to unregister.
+Within your config file (typically found at `config/defaults.php`) define an array of page templates you would like to register or unregister.
+
+**Please Note:** Page templates only need to be registered if they are more than two levels deep, e.g `./resources/templates/example.php`. This is because WordPress automatically scans themes for templates that are one or two levels deep. 
 
 There are already class constants defined for the Genesis archive and blog templates.
 
@@ -18,6 +20,9 @@ For example:
 use D2\Core\PageTemplate;
 
 $d2_page_templates = [
+    PageTemplate::REGISTER   => [
+        '/resources/templates/example.php' => 'Example Template',
+    ],
     PageTemplate::UNREGISTER => [
         PageTemplate::ARCHIVE,
         PageTemplate::BLOG,

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "d2/core-page-templates",
   "type": "library",
-  "description": "Unregister page templates through configuration.",
+  "description": "Register and unregister page templates through configuration.",
   "homepage": "https://d2themes.com/",
   "keywords": [
     "WordPress",
@@ -12,6 +12,11 @@
     {
       "name": "Craig Simpson",
       "homepage": "https://craigsimpson.scot",
+      "role": "Developer"
+    },
+    {
+      "name": "Lee Anthony",
+      "homepage": "https://seothemes.com",
       "role": "Developer"
     }
   ],

--- a/src/PageTemplate.php
+++ b/src/PageTemplate.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unregister page templates through configuration.
+ * Register and unregister page templates through configuration.
  *
  * @package   D2\Core
  * @author    Craig Simpson <craig@craigsimpson.scot>
@@ -11,7 +11,7 @@
 namespace D2\Core;
 
 /**
- * Unregister page templates through configuration.
+ * Register and unregister page templates through configuration.
  *
  * Example config (usually located at config/defaults.php):
  *
@@ -19,6 +19,9 @@ namespace D2\Core;
  * use D2\Core\PageTemplate;
  *
  * $d2_page_templates = [
+ *     PageTemplate::REGISTER   => [
+ *         '/resources/views/example.php' => 'Example Template',
+ *     ],
  *     PageTemplate::UNREGISTER => [
  *         PageTemplate::ARCHIVE,
  *         PageTemplate::BLOG,
@@ -34,23 +37,44 @@ namespace D2\Core;
  */
 class PageTemplate extends Core {
 
+	const REGISTER = 'register';
 	const UNREGISTER = 'unregister';
-	const ARCHIVE    = 'page_archive.php';
-	const BLOG       = 'page_blog.php';
+	const ARCHIVE = 'page_archive.php';
+	const BLOG = 'page_blog.php';
 
 	/**
-	 * Add filter to unregister page templates.
+	 * Add filter to register and unregister page templates.
+	 *
+	 * @since 0.2.0
 	 *
 	 * @return void
 	 */
 	public function init() {
+		if ( array_key_exists( self::REGISTER, $this->config ) ) {
+			add_filter( 'theme_page_templates', [ $this, 'add_templates' ] );
+		}
 		if ( array_key_exists( self::UNREGISTER, $this->config ) ) {
 			add_filter( 'theme_page_templates', [ $this, 'remove_templates' ] );
 		}
 	}
 
 	/**
+	 * Description of expected behavior.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param array $templates Templates to register.
+	 *
+	 * @return array
+	 */
+	public function add_templates( $templates ) {
+		return array_merge( $templates, $this->config[ self::REGISTER ] );
+	}
+
+	/**
 	 * Unregister page templates through configuration.
+	 *
+	 * @since 0.1.0
 	 *
 	 * @param array $templates Registered page templates.
 	 *


### PR DESCRIPTION
By default, WP only scans the theme's root directory and first level sub directories. This can be annoying if we want to keep templates in directories that are more than two levels deep.

This PR adds a simple method which allows additional templates to be specified from the config.